### PR TITLE
feat: update swift version to 6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
For xcode 16, the required swift version is 6.0. #144 

Below are links to resources to prove the point.

https://swiftversion.net/
https://forums.swift.org/t/swift-testing-with-swiftpm-using-xcode-16-and-swift-6/72372